### PR TITLE
detects missing versions to fail fast

### DIFF
--- a/cmds/default.sh
+++ b/cmds/default.sh
@@ -20,6 +20,12 @@ if [ -z "$version" ]; then
   fi
 fi
 
+# Check if the version is already installed
+if [ ! -f "$HOME/.pnpmvm/$version" ]; then
+  echo "Version $version is not installed. Please install it first. (pnpmvm install $version)"
+  exit 1
+fi
+
 # Assume version is semantic for now. In the future, support latest6, latest7, latest8, latest, etc.
 echo "$version" > "$default_version_file"
 echo "Wrote version $version to $default_version_file"

--- a/cmds/install.sh
+++ b/cmds/install.sh
@@ -174,7 +174,7 @@ download_and_install_pnpm() {
 
 
 # Script starts here:
-version="$1"
+version=${1:-}
 
 if [ -z "${version}" ]; then
   get_latest_version

--- a/cmds/run.sh
+++ b/cmds/run.sh
@@ -61,8 +61,10 @@ else
   exit 1
 fi
 
-# todo: Check if the version is already installed and install it
-# for now, assume the version is installed
+if [ ! -f "$HOME/.pnpmvm/$pnpm_version" ]; then
+  echo "Version $pnpm_version is not installed. Please install it first. (pnpmvm install $pnpm_version)"
+  exit 1
+fi
 
 # Pass all the original arguments to the pnpm executable
 pnpm_executable_path="$base_dir/$pnpm_version/pnpm"

--- a/cmds/use.sh
+++ b/cmds/use.sh
@@ -8,7 +8,13 @@ set -u # exit on unset variables
 
 version=${1:-}
 if [ -z "$version" ]; then
-  echo "No version provided. Please supply a version number. (ex: pnpmvm use 8.9.2)"
+  echo "No version provided. Please supply a version number. Example: (pnpmvm use 8.9.2)"
+  exit 1
+fi
+
+# Check if the version is already installed
+if [ ! -f "$HOME/.pnpmvm/$version" ]; then
+  echo "Version $version is not installed. Please install it first. (pnpmvm install $version)"
   exit 1
 fi
 
@@ -21,3 +27,5 @@ fi
 tmp_version_file="/tmp/PNPMVM_VERSION_$parent_pid"
 echo "$version" > "$tmp_version_file"
 echo "Using version: $version via $tmp_version_file"
+
+


### PR DESCRIPTION
Adds missing version detection to the following commands:

* use
* default
* run (would be triggered if a repo has a `.pnpmvmrc` file set for a version that isn't installed)

Also fixes `pnpmvm install` without specifying a version.