### PR TITLE
fix: search location for installed pnpm

### DIFF
--- a/cmds/default.sh
+++ b/cmds/default.sh
@@ -21,7 +21,7 @@ if [ -z "$version" ]; then
 fi
 
 # Check if the version is already installed
-if [ ! -f "$HOME/.pnpmvm/$version" ]; then
+if [ ! -f "$HOME/.pnpmvm/$version/pnpm" ]; then
   echo "Version $version is not installed. Please install it first. (pnpmvm install $version)"
   exit 1
 fi

--- a/cmds/use.sh
+++ b/cmds/use.sh
@@ -13,7 +13,7 @@ if [ -z "$version" ]; then
 fi
 
 # Check if the version is already installed
-if [ ! -f "$HOME/.pnpmvm/$version" ]; then
+if [ ! -f "$HOME/.pnpmvm/$version/pnpm" ]; then
   echo "Version $version is not installed. Please install it first. (pnpmvm install $version)"
   exit 1
 fi


### PR DESCRIPTION
This will fix `use` and `default` scripts which look for pre-installed pnpm versions