### PR TITLE
adds additional tests, fixes 2 bugs testing uncovered

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ curl -H 'Cache-Control: no-cache' -o- https://raw.githubusercontent.com/pkg-mgr/
 
 ```sh
 rm -rf ~/.pnpmvm /usr/local/bin/pnpm /usr/local/bin/pnpmvm /usr/local/bin/pvm
+# or simply:
+pvm nuke
 ```
 
 ## Usage
 
-Once installed, you need to install at least one version of pnpm.
+Once pvm is installed, you need to install at least one version of pnpm (ex: `pvm install 8.9.2`). You are now ready to use pnpm. You can then install additional versions the same way and switch between them with `pvm use <version>`.
 
-You can specify a default version, or use a specific version.
+You can also specify a default version for a new shell session where you have not run the `pvm use <version>` command.
 
 In addition, if you create a .pnpmvmrc file with a version in the same folder as a package.json file, any pnpm command run in that folder will automatically use the specified version.
 
@@ -40,6 +42,7 @@ Example:
 echo "8.9.2" > .pnpmvmrc
 pnpm --version
 ```
+(The `.pnpmvmrc` must be in the same directory as your project's `package.json` file.)
 
 ## How It Works
 * Individual command scripts are installed to `~/.pnpmvm/cmds`` folder

--- a/cmds/default.sh
+++ b/cmds/default.sh
@@ -22,7 +22,7 @@ if [ -z "$version" ]; then
 fi
 
 # If not checking the default version...
-if [ -z "$default_version" ]; then
+if [ -z "${default_version:-}" ]; then
   # Check if the version is already installed
   if [ ! -f "$HOME/.pnpmvm/$version/pnpm" ]; then
     echo "Version $version is not installed. Please install it first. (pvm install $version)"

--- a/cmds/default.sh
+++ b/cmds/default.sh
@@ -18,6 +18,7 @@ if [ -z "$version" ]; then
     version="$default_version"
   else
     echo "No default version set."
+    exit 0
   fi
 fi
 

--- a/cmds/install.sh
+++ b/cmds/install.sh
@@ -236,4 +236,4 @@ if [[ ! -f $default_version_file ]]; then
 fi
 
 # use the newly-installed version:
-"$base_dir/cmds/cmd.sh" use "$version"
+"$base_dir/cmds/use.sh" "$version"

--- a/test.sh
+++ b/test.sh
@@ -35,6 +35,13 @@ cmd_should_exist() {
   fi
 }
 
+dir_should_exist() {
+  if [[ ! -d $1 ]]; then
+    echo "Directory does not exist $1"
+    exit 1
+  fi
+}
+
 uninstall_pnpmvm() {
   echo "y" | ./cmds/nuke.sh
   error_if_dir_exists "$base_dir"
@@ -61,6 +68,17 @@ check_current_pnpm_version() {
   fi
 }
 
+function check_output_contains_str() {
+  if [[ "$2" != *"$1"* ]]; then
+    echo "Expected string not detected."
+    echo "Expected: $1"
+    echo "Received: $2"
+    exit 1
+  fi
+}
+
+### Beginning of Tests ###
+
 echo "*** Initial setup, removing any existing install..."
 uninstall_pnpmvm
 
@@ -79,5 +97,42 @@ echo "Checking that default version has been set..."
 check_pvm_default_version "8.9.2"
 echo "Checking that current pnpm version is correct..."
 check_current_pnpm_version "8.9.2"
+
+echo "Test installing a major version..."
+pvm install 7
+file_should_exist "$base_dir/7.9.5/pnpm"
+check_current_pnpm_version "7.9.5"
+
+echo "Test that pvm list shows both versions..."
+list_output=$(pvm list > /dev/null 2>&1)
+check_output_contains_str "$list_output" "8.9.2"
+check_output_contains_str "$list_output" "7.9.5"
+
+echo "Test using a different version..."
+pvm use 8.9.2
+check_current_pnpm_version "8.9.2"
+pvm use 7.9.5
+check_current_pnpm_version "7.9.5"
+
+echo "Test unusing, should fall back to default version..."
+pvm unuse
+check_current_pnpm_version "8.9.2"
+
+echo "Test changing the default version..."
+pvm default 7.9.5
+check_current_pnpm_version "7.9.5"
+
+echo "Test uninstalling a version..."
+pvm uninstall 7.9.5
+error_if_dir_exists "$base_dir/7.9.5"
+
+echo "Installing an invalid version should not work or delete anything else."
+pvm install 3 > /dev/null 2>&1 || true # ignore err
+dir_should_exist "$base_dir"
+dir_should_exist "$base_dir/8.9.2"
+
+echo "Help command should display text..."
+help_output=$(pvm help > /dev/null 2>&1)
+check_output_contains_str "$help_output" "Available commands:"
 
 echo "*** All tests passed! ***"


### PR DESCRIPTION
* Updates readme for better description of basic usage
* Adds tests
* Fixes bug where `pvm install <version>` did not correctly call `pvm use`
* Fixes bug where `pvm default` threw an error when there was no default version