### PR TITLE
feat: separate version check script

### DIFF
--- a/cmds/default.sh
+++ b/cmds/default.sh
@@ -6,33 +6,39 @@ set -e # exit on errors
 set -o pipefail # exit on pipe failure
 set -u # exit on unset variables
 
-version=${1:-}
+# version=$(./cmds/resolve_version.sh "${1:-}")
+# echo $version
 base_dir="$HOME/.pnpmvm"
 default_version_file="$base_dir/default-version.txt"
 
-# if no version is provided, report the current version instead
-if [ -z "$version" ]; then
+default_exists() {
   if [ -f "$default_version_file" ]; then
     default_version=$(head -n 1 "$default_version_file")
-    echo "Current default version: $default_version"
-    version="$default_version"
+    echo "Current default version is $default_version"
   else
-    echo "No default version set."
+    echo "No default version set." > `tty`
+    exit 0
   fi
+}
+
+# if no version is provided, report the current version instead
+if [ $# -eq 0 ]; then
+  default_exists
+  exit 0
 fi
 
-# If not checking the default version...
-if [ -z "$default_version" ]; then
-  # Check if the version is already installed
-  if [ ! -f "$HOME/.pnpmvm/$version/pnpm" ]; then
-    echo "Version $version is not installed. Please install it first. (pvm install $version)"
-    exit 1
-  fi
-  # Next, set the new default version:
-  # (Assume version is semantic for now.)
-  echo "$version" > "$default_version_file"
-  echo "Setting default version to $version"
-  if [ "$PNPMVM_DEBUG" = "true" ]; then
-    echo "DEBUG: Wrote version $version to $default_version_file"
-  fi
+# since a version is provided here, we should resolve the input
+version=$(./cmds/resolve_version.sh "$1")
+
+# Check if the version is already installed
+if [ ! -f "$HOME/.pnpmvm/$version/pnpm" ]; then
+  echo "Version $version is not installed. Please install it first. (pvm install $version)"
+  exit 1
+fi
+
+# Next, set the new default version:
+echo "$version" > "$default_version_file"
+echo "Setting default version to $version"
+if [ "$PNPMVM_DEBUG" = "true" ]; then
+  echo "DEBUG: Wrote version $version to $default_version_file"
 fi

--- a/cmds/default.sh
+++ b/cmds/default.sh
@@ -14,9 +14,9 @@ default_version_file="$base_dir/default-version.txt"
 default_exists() {
   if [ -f "$default_version_file" ]; then
     default_version=$(head -n 1 "$default_version_file")
-    echo "Current default version is $default_version"
+    echo "$default_version"
   else
-    echo "No default version set." > `tty`
+    echo "No default version set." > "$(tty)"
     exit 0
   fi
 }

--- a/cmds/install.sh
+++ b/cmds/install.sh
@@ -157,26 +157,8 @@ download_and_install_pnpm() {
   local platform arch version_json archive_url
   platform="$(detect_platform)"
   arch="$(detect_arch)" || abort "Sorry! pnpm currently only provides pre-built binaries for x86_64/arm64 architectures."
-  
-  # checks to see if input is a single positive major version integer
-  # if yes, goes to find the latest of that major and set version to the latest
-  if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.\w]*)$ ]]; then
-    # matches `6.32.4` or `7.0.0-rc.0`
-    echo "Semantic version specified"
-  elif [[ $version =~ ^[0-9]$ ]] && ((version > 0)); then
-    # Major version specified
-    echo major version specified
-    version=$(find_version "$version")
-    echo "Resolved version: $version"
-  else
-    echo "
-      Invalid version format.  Try:
-      pvm install
-      pvm install 8
-      pvm install 8.9.2
-    "
-    exit 1
-  fi
+
+  version=$(./cmds/resolve_version.sh "$version")
 
   install_dir="$base_dir/$version"
   ensure_dir "$base_dir"

--- a/cmds/resolve_version.sh
+++ b/cmds/resolve_version.sh
@@ -1,0 +1,39 @@
+#/bin/bash
+
+# Checks for single-digit major inputs and returns full version numbers
+
+set -e # exit on errors
+set -o pipefail # exit on pipe failure
+set -u # exit on unset variables
+
+find_version() {
+  # The first argument is the major version number
+  local major_version=$1
+
+  # Read the file and find the line
+  resolved_major=$(grep "^$major_version\." "$HOME/.pnpmvm/versions.txt" | grep "^[0-9\.-]*$" | tail -n 1)
+
+  # Return the result
+  echo "$resolved_major"
+}
+
+# checks to see if input is a single positive major version integer
+# if yes, goes to find the latest of that major and set version to the latest
+if [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.\w]*)$ ]]; then
+  # matches `6.32.4` or `7.0.0-rc.0`
+  # semantic version specified
+  echo $1
+
+  elif [[ $1 =~ ^[0-9]$ ]] && (($1 > 0)); then
+  # Major version specified
+  echo $(find_version "$1")
+
+  else
+  echo "
+      Invalid version format.  Try:
+      pvm install
+      pvm install 8
+      pvm install 8.9.2
+  " > `tty`
+  exit 1
+fi

--- a/cmds/resolve_version.sh
+++ b/cmds/resolve_version.sh
@@ -34,6 +34,8 @@ if [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.\w]*)$ ]]; then
       pvm install
       pvm install 8
       pvm install 8.9.2
+      pvm use 7
+      pvm use 7.32.0
   " > `tty`
   exit 1
 fi

--- a/cmds/resolve_version.sh
+++ b/cmds/resolve_version.sh
@@ -30,12 +30,11 @@ if [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.\w]*)$ ]]; then
 
   else
   echo "
-      Invalid version format.  Try:
-      pvm install
+      Invalid version format.
+      Enter an existing major version or a semantic version.
+      Example:
       pvm install 8
-      pvm install 8.9.2
-      pvm use 7
-      pvm use 7.32.0
+      pvm use 6.17.1
   " > `tty`
   exit 1
 fi

--- a/cmds/use.sh
+++ b/cmds/use.sh
@@ -6,11 +6,7 @@ set -e # exit on errors
 set -o pipefail # exit on pipe failure
 set -u # exit on unset variables
 
-version=${1:-}
-if [ -z "$version" ]; then
-  echo "No version provided. Please supply a version number. Example: (pvm use 8.9.2)"
-  exit 1
-fi
+version=$(./cmds/resolve_version.sh "${1:-}")
 
 # Check if the version is already installed
 if [ ! -f "$HOME/.pnpmvm/$version/pnpm" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@ set -u # exit on unset variables
 
 base_dir="$HOME/.pnpmvm"
 cmds_dir="$base_dir/cmds"
-cmd_list="cmd default help install list nuke run uninstall unuse update use"
+cmd_list="cmd default help install list nuke run uninstall unuse update use resolve_version"
 NUKE_PNPM=${NUKE_PNPM:-0}
 
 ensure_dir() {

--- a/test.sh
+++ b/test.sh
@@ -53,8 +53,8 @@ uninstall_pnpmvm() {
 check_pvm_default_version() {
   local expected_version=$1
   default_version_output=$(pvm default)
-  if [[ ! $default_version_output == "Current default version: $expected_version" ]]; then
-    echo "Current default version $default_version_output doesn't match expected version $expected_version"
+  if [[ ! $default_version_output == "$expected_version" ]]; then
+    echo "Output '$default_version_output' doesn't match expected '$expected_version'"
     exit 1
   fi
 }


### PR DESCRIPTION
This separates the version resolving checker functionality out to its own script.

I have also taken the liberty to implement it in `install`, `use`, and `default` commands.