### PR TITLE
test fixes

### DIFF
--- a/cmds/install.sh
+++ b/cmds/install.sh
@@ -10,6 +10,8 @@ base_dir="$HOME/.pvm"
 cmds_dir="$base_dir/cmds"
 default_version_file="$base_dir/default-version.txt"
 
+# todo: handle $1 undefined?
+
 ensure_dir() {
   if [ ! -d "$1" ]; then
     mkdir -p "$1"


### PR DESCRIPTION
Fixes case where tests could pass when no command output was supplied to `check_output_contains_str` function.